### PR TITLE
WEBBPMNEXT-8997: добавил проверку на входной параметр

### DIFF
--- a/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/DiagramSet.java
+++ b/packages/stunner-editors/kie-wb-common-stunner/kie-wb-common-stunner-sets/kie-wb-common-stunner-bpmn/kie-wb-common-stunner-bpmn-api/src/main/java/org/kie/workbench/common/stunner/bpmn/definition/property/diagram/DiagramSet.java
@@ -280,7 +280,7 @@ public class DiagramSet implements BaseDiagramSet {
     }
 
     public static native void updateEditorProcessId(String processId)/*-{
-        if (parent && parent.parent && parent.parent.processId) {
+        if (processId && parent && parent.parent && parent.parent.processId) {
             parent.parent.processId = processId;
         }
     }-*/;


### PR DESCRIPTION
Переоткрыл по причине: если попробовать ввести пустой ID в инспекторе, то файлы сохранятся с пустым именем, останется лишь расширение. Поэтому добавил проверку на processId.

http://codereview.asd.center.cg/cru/WEBBPM2-7584